### PR TITLE
Add the avatar to the user info + general cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # OmniAuth Intercom
 
 Intercom OAuth2 Strategy for OmniAuth.
@@ -56,9 +55,9 @@ Here's an example *Auth Hash* available in `request.env['omniauth.auth']`:
       :id => '342324',
       :app => {
         :id_code => 'abc123', # Company app_id
-        :type: 'app',
-        secure: true # Secure mode enabled for this app
-      }
+        :type => 'app',
+        :secure => true # Secure mode enabled for this app
+      },
       :avatar => {
         :image_url => "https://static.intercomassets.com/avatars/343616/square_128/me.jpg?1454165491"
       }

--- a/spec/omniauth/intercom_spec.rb
+++ b/spec/omniauth/intercom_spec.rb
@@ -2,6 +2,6 @@ require 'spec_helper'
 
 describe OmniAuth::Intercom do
   it 'has a version number' do
-    expect(OmniAuth::Intercom::VERSION).not_to be nil
+    expect(OmniAuth::Intercom::VERSION).to match(/(\d+\.){2}\d+/)
   end
 end

--- a/spec/omniauth/strategies/intercom_spec.rb
+++ b/spec/omniauth/strategies/intercom_spec.rb
@@ -5,7 +5,7 @@ describe OmniAuth::Strategies::Intercom do
 
   let(:access_token) { stub('AccessToken', :options => {})}
   let(:token) { 'some-token' }
-  let(:parsed_response) { {:email => 'kevin.antoine@intercom.io', :name => 'Kevin Antoine'} }
+  let(:parsed_response) { JSON.parse({ :email => 'kevin.antoine@intercom.io', :name => 'Kevin Antoine', :avatar => { :image_url => 'https://static.intercomassets.com/avatars/343616/square_128/me.jpg?1454165491' } }.to_json) }
   let(:response) { stub('Response', :parsed => parsed_response) }
   let(:client) { stub('Client') }
   let(:connection) { stub('Connection') }
@@ -16,32 +16,70 @@ describe OmniAuth::Strategies::Intercom do
     OmniAuth::Strategies::Intercom.new({})
   end
 
-  before(:each) do
+  before do
+    OmniAuth.config.full_host = 'http://test.host'
     allow(subject).to receive(:access_token).and_return access_token
     allow(access_token).to receive(:client).and_return client
+    allow(access_token).to receive(:options).and_return options
+    allow(access_token).to receive(:token).and_return token
+    allow(access_token).to receive(:get).with('/me').and_return response
     allow(client).to receive(:connection).and_return connection
     allow(connection).to receive(:headers).and_return headers
     allow(connection).to receive(:basic_auth).and_return "Bearer #{token}"
-    allow(access_token).to receive(:options).and_return options
-    allow(access_token).to receive(:token).and_return token
     allow(response).to receive(:parsed).and_return parsed_response
   end
 
-  context "#raw_info" do
-    it "should return raw_info" do
+  context '#raw_info' do
+    it 'request "me"' do
       expect(access_token).to receive(:get).with('/me').and_return response
+
+      subject.raw_info
+    end
+
+    it 'returns the raw_info' do
       expect(subject.raw_info).to eq parsed_response
     end
   end
-  context "#signup" do
+
+  context '#info' do
+    it 'should have the name' do
+      expect(subject.info[:name]).to eq('Kevin Antoine')
+    end
+
+    it 'should have the email' do
+      expect(subject.info[:email]).to eq('kevin.antoine@intercom.io')
+    end
+
+    it 'should have the image' do
+      expect(subject.info[:image]).to eq('https://static.intercomassets.com/avatars/343616/square_128/me.jpg?1454165491')
+    end
+
+    context 'when the avatar is not available' do
+      before do
+        parsed_response.delete('avatar')
+      end
+
+      it 'should have the image' do
+        expect(subject.info[:image]).to eq(nil)
+      end
+    end
+  end
+
+  context 'when using signup' do
     let(:params) { { 'signup' => '1' } }
+
     before do
-      allow(subject).to receive(:request).and_return Object.new()
       allow(subject.request).to receive(:params).and_return params
     end
-    it "should change authorize_url to signup" do
-      subject.send(:authorize_url)
-      expect(subject.options.client_options[:authorize_url]).to eq 'https://app.intercom.io/oauth/signup'
+
+    context 'when the request phase starts' do
+      before do
+        subject.request_phase rescue nil
+      end
+
+      it 'changes the authorize_url to signup' do
+        expect(subject.options.client_options[:authorize_url]).to eq('https://app.intercom.io/oauth/signup')
+      end
     end
   end
 end

--- a/spec/omniauth/strategies/intercom_spec.rb
+++ b/spec/omniauth/strategies/intercom_spec.rb
@@ -2,13 +2,12 @@
 require 'spec_helper'
 
 describe OmniAuth::Strategies::Intercom do
-
-  let(:access_token) { stub('AccessToken', :options => {})}
+  let(:access_token) { double('AccessToken', :options => {}) }
   let(:token) { 'some-token' }
   let(:parsed_response) { JSON.parse({ :email => 'kevin.antoine@intercom.io', :name => 'Kevin Antoine', :avatar => { :image_url => 'https://static.intercomassets.com/avatars/343616/square_128/me.jpg?1454165491' } }.to_json) }
-  let(:response) { stub('Response', :parsed => parsed_response) }
-  let(:client) { stub('Client') }
-  let(:connection) { stub('Connection') }
+  let(:response) { double('Response', :parsed => parsed_response) }
+  let(:client) { double('Client') }
+  let(:connection) { double('Connection') }
   let(:headers) { {} }
   let(:options) { {} }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,6 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'omniauth/intercom'
+
+RSpec.configure do |config|
+  config.raise_errors_for_deprecations!
+end


### PR DESCRIPTION
- Added tests for user information and raw info contents.
- Simplified logic / testing around the `/signup` endpoint.
- Removed boilerplate comments
- Fixed a syntax error in sample response hash given in the docs
