### PR TITLE
Readme example syntax fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ Here's an example *Auth Hash* available in `request.env['omniauth.auth']`:
         :id_code => 'abc123', # Company app_id
         :type => 'app',
         :secure => true, # Secure mode enabled for this app
-	:timezone => "Dublin",
-	:name => "ProjectMap"
+        :timezone => "Dublin",
+        :name => "ProjectMap"
       },
       :avatar => {
         :image_url => "https://static.intercomassets.com/avatars/343616/square_128/me.jpg?1454165491"

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Here's an example *Auth Hash* available in `request.env['omniauth.auth']`:
       :app => {
         :id_code => 'abc123', # Company app_id
         :type => 'app',
-        :secure => true # Secure mode enabled for this app
+        :secure => true, # Secure mode enabled for this app
 	:timezone => "Dublin",
 	:name => "ProjectMap"
       },


### PR DESCRIPTION
 - JSON example was missing a `,` making the response example invalid.
 - Tabbing was off in formatting.