### PR TITLE
Fix compatibility with Faraday 2.0

### DIFF
--- a/lib/omniauth/strategies/intercom.rb
+++ b/lib/omniauth/strategies/intercom.rb
@@ -1,5 +1,5 @@
 require 'omniauth-oauth2'
-require 'uri'
+require 'base64'
 
 module OmniAuth
   module Strategies
@@ -53,9 +53,13 @@ module OmniAuth
       protected
 
       def accept_headers
-        access_token.client.connection.headers['Authorization'] = access_token.client.connection.basic_auth(access_token.token, '')
+        access_token.client.connection.headers['Authorization'] = "Basic #{basic_auth_credentials}"
         access_token.client.connection.headers['Accept'] = "application/vnd.intercom.3+json"
         access_token.client.connection.headers['User-Agent'] = "omniauth-intercom/#{::OmniAuth::Intercom::VERSION}"
+      end
+
+      def basic_auth_credentials
+        Base64.encode64("#{access_token.token}:").delete("\n")
       end
 
       def prepopulate_signup_fields_form

--- a/omniauth-intercom.gemspec
+++ b/omniauth-intercom.gemspec
@@ -17,7 +17,9 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+
   spec.add_runtime_dependency 'omniauth-oauth2', '>= 1.2'
+  spec.add_runtime_dependency 'base64'
 
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/spec/omniauth/strategies/intercom_spec.rb
+++ b/spec/omniauth/strategies/intercom_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 describe OmniAuth::Strategies::Intercom do
-  let(:access_token) { double('AccessToken', options: {}) }
+  let(:access_token) { instance_double(OAuth2::AccessToken) }
   let(:token) { 'some-token' }
-  let(:client) { double('Client') }
-  let(:connection) { double('Connection') }
+  let(:client) { instance_double(OAuth2::Client) }
+  let(:connection) { instance_double(Faraday::Connection) }
   let(:headers) { {} }
   let(:options) { {} }
 
@@ -21,12 +21,11 @@ describe OmniAuth::Strategies::Intercom do
 
     allow(client).to receive(:connection).and_return connection
     allow(connection).to receive(:headers).and_return headers
-    allow(connection).to receive(:basic_auth).and_return "Bearer #{token}"
   end
 
   context 'with verified email' do
     let(:parsed_response) { JSON.parse({email: 'kevin.antoine@intercom.io', name: 'Kevin Antoine', avatar: {image_url: 'https://static.intercomassets.com/avatars/343616/square_128/me.jpg?1454165491'}, email_verified: true}.to_json) }
-    let(:response) { double('Response', :parsed => parsed_response) }
+    let(:response) { instance_double(OAuth2::Response, :parsed => parsed_response) }
 
     before do
       allow(access_token).to receive(:get).with('/me').and_return response
@@ -103,7 +102,7 @@ describe OmniAuth::Strategies::Intercom do
 
   context 'with unverified email' do
     let(:parsed_response) { JSON.parse({email: 'kevin.antoine@intercom.io', name: 'Kevin Antoine', avatar: {image_url: 'https://static.intercomassets.com/avatars/343616/square_128/me.jpg?1454165491'}, email_verified: false}.to_json) }
-    let(:response) { double('Response', :parsed => parsed_response) }
+    let(:response) { instance_double(OAuth2::Response, :parsed => parsed_response) }
 
     before do
       allow(access_token).to receive(:get).with('/me').and_return response


### PR DESCRIPTION
`Faraday::Connection#basic_auth` was [deprecated](https://github.com/lostisland/faraday/commit/fa612a060adffd2d7bdb73e46610f4f8aec09220) in Faraday 1.10 and [removed](https://github.com/lostisland/faraday/commit/fe600c72adc79180ad7e545191edd5dd2fe61990) in Faraday 2.0. Building an Authorization header is not that involved, we can do it ourselves.